### PR TITLE
MNT: Use noarch python {{ python_min }} variable

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Summary: Matplotlib styles for HEP
 
 Development: https://github.com/scikit-hep/mplhep
 
+Documentation: https://mplhep.readthedocs.io/
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,49 @@
 {% set name = "mplhep" %}
 {% set version = "0.3.55" %}
+{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 0fb87cd4b025225ba8fd5d82d58324cfb094fbcdd7929e5a9ea1ea7e22108814
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python {{ python_min }}
     - hatchling
     - hatch-vcs
   run:
     - matplotlib-base >=3.4
     - numpy >=1.16.0
     - packaging
-    - python >=3.7
-    - mplhep_data
+    - python >={{ python_min }}
+    - mplhep_data >=0.0.4
     - uhi >=0.2.0
 
 test:
+  requires:
+    - python {{ python_min }}
+    - pip
   imports:
     - mplhep
+  commands:
+    - pip check
 
 about:
   home: https://github.com/scikit-hep/mplhep
   license: MIT
   license_file: LICENSE
   summary: Matplotlib styles for HEP
+  doc_url: https://mplhep.readthedocs.io/
   dev_url: https://github.com/scikit-hep/mplhep
 
 extra:


### PR DESCRIPTION
* Use 'python {{ python_min }}' syntax for the python requirements for noarch python recipes.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Use a Jinja2 set statement for the python_min to allow all the build metadata to be contained in the recipe/meta.yaml and override the global python_min with mplhep's python_min of 3.8.
* Use 'pypi.org'.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
